### PR TITLE
Update README to point to maintained django-fsm-2-admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,11 +408,11 @@ $ ./manage.py graph_transitions -o blog_transitions.png myapp.Blog
 
 ## Extensions
 
-You may also take a look at django-fsm-admin project containing a mixin
-and template tags to integrate django-fsm state transitions into the
+You may also take a look at django-fsm-2-admin project containing a mixin
+and template tags to integrate django-fsm-2 state transitions into the
 django admin.
 
-<https://github.com/gadventures/django-fsm-admin>
+<https://github.com/coral-li/django-fsm-2-admin>
 
 Transition logging support could be achieved with help of django-fsm-log
 package


### PR DESCRIPTION
Since the [django-fsm-admin](https://github.com/gadventures/django-fsm-admin) repository is no longer maintained, we at [Coral.li](https://github.com/coral-li) have decided to fork the repository and take over its maintenance.

We’ve replaced the outdated `django-fsm` with `django-fsm-2` and updated the repository to support the latest versions of Python and Django.

Check out the updated repository here: [django-fsm-2-admin](https://github.com/coral-li/django-fsm-2-admin).