### PR TITLE
pre-commit autoupdate 2025-10-04

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
-default_language_version:
-  python: python3.12
+# default_language_version:
+#  python: python3.12
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=700"]
@@ -20,7 +20,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.32.0
+    rev: v1.37.2
     hooks:
       - id: typos
         args: []
@@ -35,21 +35,21 @@ repos:
           - "--py38-plus"
 
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: 1.25.0
+    rev: 1.28.0
     hooks:
       - id: django-upgrade
         args: [--target-version, "4.2"]
 
 
   - repo: https://github.com/python-poetry/poetry
-    rev: 1.8.0
+    rev: 2.2.1
     hooks:
       - id: poetry-check
         additional_dependencies:
-          - poetry-plugin-sort==0.2.0
+          - poetry-plugin-sort
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.12
+    rev: v0.13.3
     hooks:
       - id: ruff-format
       - id: ruff-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
-# default_language_version:
-#  python: python3.12
+default_language_version:
+  python: python3.12
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -83,7 +83,7 @@ django-fsm 2.5.0 2017-03-04
 django-fsm 2.4.0 2016-05-14
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- graph_transition commnad now works with multiple  FSM's per model
+- graph_transition command now works with multiple  FSM's per model
 - Add ability to set target state from transition return value or callable
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ extend-ignore = [
     "EM102",  # Exception must not use an f-string literal, assign to variable first
     "SLF001",  # Private member accessed
     "SIM103",  # Return the condition directly
+    "PLC0415",  # `import` should be at the top-level of a file
     "PLR0913",  # Too many arguments in function definition
 ]
 fixable = [


### PR DESCRIPTION
% `pre-commit autoupdate`
```
[https://github.com/pre-commit/pre-commit-hooks] updating v5.0.0 -> v6.0.0
[https://github.com/crate-ci/typos] updating v1.32.0 -> v1
[https://github.com/asottile/pyupgrade] already up to date!
[https://github.com/adamchainz/django-upgrade] updating 1.25.0 -> 1.28.0
[https://github.com/python-poetry/poetry] updating 1.8.0 -> 2.2.1
[https://github.com/astral-sh/ruff-pre-commit] updating v0.11.12 -> v0.13.3
```
% `pre-commit run --all-files`

---
There are lots of perfectly valid reasons to ignore:
% `ruff rule PLC0415`
# import-outside-top-level (PLC0415)

Derived from the **Pylint** linter.

## What it does
Checks for `import` statements outside of a module's top-level scope, such
as within a function or class definition.

## Why is this bad?
[PEP 8] recommends placing imports not only at the top-level of a module,
but at the very top of the file, "just after any module comments and
docstrings, and before module globals and constants."

`import` statements have effects that are global in scope; defining them at
the top level has a number of benefits. For example, it makes it easier to
identify the dependencies of a module, and ensures that any invalid imports
are caught regardless of whether a specific function is called or class is
instantiated.

An import statement would typically be placed within a function only to
avoid a circular dependency, to defer a costly module load, or to avoid
loading a dependency altogether in a certain runtime environment.

## Example
```python
def print_python_version():
    import platform

    print(platform.python_version())
```

Use instead:
```python
import platform


def print_python_version():
    print(platform.python_version())
```

## See also
This rule will ignore import statements configured in
[`lint.flake8-tidy-imports.banned-module-level-imports`][banned-module-level-imports]
if the rule [`banned-module-level-imports`][TID253] is enabled.

[banned-module-level-imports]: https://docs.astral.sh/ruff/settings/#lint_flake8-tidy-imports_banned-module-level-imports
[TID253]: https://docs.astral.sh/ruff/rules/banned-module-level-imports/
[PEP 8]: https://peps.python.org/pep-0008/#imports
