### PR TITLE
feat: Add support for Django 6.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,10 @@
 Changelog
 =========
 
-Unreleased
+django-fsm-2 4.1.0 unreleased
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+- Add support for Django 6.0
 - Add support for Django 5.2
 - Add support for python 3.13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.8',
@@ -29,6 +30,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Topic :: Software Development :: Libraries :: Python Modules',
 ]
 packages = [{ include = "django_fsm" }]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist =
     py{310,311,312}-dj50
     py{310,311,312}-dj51
     py{310,311,312,313,314}-dj52
-    # py{312,313,314}-djmain
+    py{312,313,314}-dj60
+    py{312,313,314}-djmain
 
 skipsdist = True
 
@@ -14,6 +15,7 @@ deps =
     dj50: Django==5.0
     dj51: Django==5.1
     dj52: Django==5.2
+    dj60: Django>=6.0a1,<6.1
     djmain: https://github.com/django/django/tarball/main
 
     django-guardian


### PR DESCRIPTION
This PR adds Django 6.0 compatibility and updates the test matrix.

The key change is that a model's `_do_update` method requires a 7th positional parameter `returning_fields`. 

https://github.com/charettes/django/commit/55a0073b3beb9de8f7c1f7c44a7d0bc10126c841
