### PR TITLE
Update Tox for Django6.1 final version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
     dj51: Django==5.1
     dj52: Django==5.2
     dj60: Django==6.0
-    dj61: Django==6.1a1
+    dj61: Django==6.1
     djmain: https://github.com/django/django/tarball/main
 
     django-fsm-log


### PR DESCRIPTION
## Description

Update tox with Django 6.1 final version.

NB: Created to investigate this CI issue: https://github.com/django-commons/django-fsm-2/actions/runs/30422922967/job/92538100299

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Other (no functional changes)

## Checklist

- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
- [ ] Tests added/updated for the changes
- [ ] All tests pass locally (`uv run pytest` or `pytest`)
- [ ] Linting passes (`uv run ruff check .`)
- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.rst updated (for user-facing changes)

## Testing

<!-- Describe how you tested these changes -->

```bash
# Commands used to test
uv run pytest tests/test_xxx.py -v
```

## Related Issues

<!-- Link any related issues: Fixes #123, Related to #456 -->
