### PR TITLE
Move transition buttons after save buttons

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Unreleased
 - Add Django 6.1 support
 - Add ``TransitionConditionsUnmet`` with ``failed_condition`` for unmet conditions
 - Add ``NoTransition`` and ``InvalidTransition`` subclasses for ``TransitionNotAllowed``
+- Move admin transition buttons after save buttons so that a transition is not used as the default button when pressing the Enter key (#145)
 
 
 django-fsm-2 4.2.4 2026-03-16

--- a/django_fsm/templates/django_fsm/fsm_admin_change_form.html
+++ b/django_fsm/templates/django_fsm/fsm_admin_change_form.html
@@ -1,6 +1,7 @@
 {% extends 'admin/change_form.html' %}
 
 {% block submit_buttons_bottom %}
+  {{ block.super }}
 
   {% for fsm_object_transition in fsm_object_transitions %}
       <div class="submit-row">
@@ -10,6 +11,4 @@
         {% endfor %}
       </div>
   {% endfor %}
-
-  {{ block.super }}
 {% endblock %}


### PR DESCRIPTION
## Description

* pressing Enter in any text field implicity submits using the first type="submit" button, which is currently a state transition instead of Save.
* django-fsm-admin puts the state transition buttons after the Save buttons, so this changes the order to match.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (no functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
- [ ] Tests added/updated for the changes
- [x] All tests pass locally (`uv run pytest` or `pytest`)
- [ ] Linting passes (`uv run ruff check .`)
- [ ] Documentation updated (if applicable)
- [x] CHANGELOG.rst updated (for user-facing changes)

## Testing

<!-- Describe how you tested these changes -->

```bash
# Commands used to test
uv run pytest tests/test_xxx.py -v
```

## Related Issues

<!-- Link any related issues: Fixes #123, Related to #456 -->
