### PR TITLE
Enforce transition permission in admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,15 @@ Unreleased
 - Add ``TransitionConditionsUnmet`` with ``failed_condition`` for unmet conditions
 - Add ``NoTransition`` and ``InvalidTransition`` subclasses for ``TransitionNotAllowed``
 - Move admin transition buttons after save buttons so that a transition is not used as the default button when pressing the Enter key (#145)
+- Fix ``FSMAdminMixin`` not enforcing a transition's ``permission`` when applied via
+  ``_apply_fsm_transition`` directly, i.e. the submit-row button for transitions with no
+  form configured (the common case), or custom admin actions that call
+  ``_apply_fsm_transition``. Transitions with a form were already protected by the
+  existing ``has_perm()`` check in ``fsm_transition_view``. **Behavior change:** if you
+  have a ``permission`` set on a transition, it is now actually enforced on these paths,
+  where it previously silently was not
+- Fix ``FSMAdminMixin`` not writing a Django admin ``LogEntry`` for applied transitions,
+  so state changes made in the admin no longer disappear from the object's "History"
 
 
 django-fsm-2 4.2.4 2026-03-16

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,8 +14,6 @@ Unreleased
   ``_apply_fsm_transition`` directly, i.e. the submit-row button for transitions with no
   form configured (the common case). **Behavior change:** if you have a
   ``permission`` set on a transition, it is now actually enforced on these paths
-- Fix ``FSMAdminMixin`` not writing a Django admin ``LogEntry`` for applied transitions,
-  so state changes made in the admin no longer disappear from the object's "History"
 - Fix stray "None"s in admin when a transition has no configured ``help_text`` (#148)
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,11 +12,8 @@ Unreleased
 - Move admin transition buttons after save buttons so that a transition is not used as the default button when pressing the Enter key (#145)
 - Fix ``FSMAdminMixin`` not enforcing a transition's ``permission`` when applied via
   ``_apply_fsm_transition`` directly, i.e. the submit-row button for transitions with no
-  form configured (the common case), or custom admin actions that call
-  ``_apply_fsm_transition``. Transitions with a form were already protected by the
-  existing ``has_perm()`` check in ``fsm_transition_view``. **Behavior change:** if you
-  have a ``permission`` set on a transition, it is now actually enforced on these paths,
-  where it previously silently was not
+  form configured (the common case). **Behavior change:** if you have a
+  ``permission`` set on a transition, it is now actually enforced on these paths
 - Fix ``FSMAdminMixin`` not writing a Django admin ``LogEntry`` for applied transitions,
   so state changes made in the admin no longer disappear from the object's "History"
 

--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -47,6 +47,13 @@ if typing.TYPE_CHECKING:  # pragma: no cover
     _Condition: typing.TypeAlias = typing.Callable[[_FSMModel], bool]
     _TransitionFunc: typing.TypeAlias = typing.Callable[..., _StateValue | typing.Any | None]
 
+    class _TransitionMethod(typing.Protocol):
+        """A `@transition`-decorated method"""
+
+        _django_fsm: FSMMeta
+
+        def __call__(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Any: ...
+
 else:
     _FSMModel = object
     _Field = object
@@ -323,7 +330,7 @@ class FSMFieldMixin(_Field):
 
     transitions: dict[  # cls -> (transitions name -> method)
         type[_FSMModel],
-        dict[str, typing.Any],
+        dict[str, _TransitionMethod],
     ]
     state_proxy: dict[_StateValue, str]  # state -> ProxyClsRef
 
@@ -505,7 +512,7 @@ class FSMFieldMixin(_Field):
                 )
             )
 
-        sender_transitions: dict[str, typing.Any] = {}
+        sender_transitions: dict[str, _TransitionMethod] = {}
         transitions = inspect.getmembers(sender, predicate=is_field_transition_method)
         for method_name, method in transitions:
             method._django_fsm.field = self

--- a/django_fsm/admin.py
+++ b/django_fsm/admin.py
@@ -230,9 +230,9 @@ class FSMAdminMixin(_ModelAdmin):
 
     def _get_fsm_transition_func(
         self, *, obj: fsm._FSMModel, transition_name: str
-    ) -> fsm._TransitionFunc:
+    ) -> fsm._TransitionMethod:
         try:
-            transition_func: fsm._TransitionFunc = getattr(obj, transition_name)
+            transition_func: fsm._TransitionMethod = getattr(obj, transition_name)
         except AttributeError:
             raise AttributeError(
                 f"{obj.__class__.__name__} has no transition method '{transition_name}'."
@@ -251,12 +251,8 @@ class FSMAdminMixin(_ModelAdmin):
         self, *, obj: fsm._FSMModel, transition_name: str
     ) -> fsm.Transition:
         transition_func = self._get_fsm_transition_func(obj=obj, transition_name=transition_name)
-        transitions = transition_func._django_fsm.transitions  # type: ignore[attr-defined]
-        if isinstance(transitions, dict):
-            transitions = list(transitions.values())
-
-        # Each transition method stores one transition per target field; first entry is sufficient.
-        return transitions[0]  # type: ignore[no-any-return]
+        # Each transition method stores one transition per source; first entry is sufficient.
+        return next(iter(transition_func._django_fsm.transitions.values()))
 
     @staticmethod
     def _is_fsm_log_enabled() -> bool:
@@ -368,7 +364,7 @@ class FSMAdminMixin(_ModelAdmin):
             self._log_fsm_transition(
                 request=request,
                 obj=obj,
-                field=transition_func._django_fsm.field,  # type: ignore[attr-defined]
+                field=transition_func._django_fsm.field,
             )
             return True
 

--- a/django_fsm/admin.py
+++ b/django_fsm/admin.py
@@ -293,15 +293,6 @@ class FSMAdminMixin(_ModelAdmin):
         )
         return False
 
-    def _log_fsm_transition(
-        self, *, request: http.HttpRequest, obj: fsm._FSMModel, field: fsm.FSMFieldMixin
-    ) -> None:
-        """Record the transition in the admin change history (LogEntry)."""
-        try:
-            self.log_change(request, obj, [{"changed": {"fields": [str(field.verbose_name)]}}])
-        except Exception:
-            logger.exception("Failed to write admin log entry for FSM transition")
-
     def _apply_fsm_transition(
         self,
         *,
@@ -360,11 +351,6 @@ class FSMAdminMixin(_ModelAdmin):
                     transition_name=transition_name,
                 ),
                 level=messages.SUCCESS,
-            )
-            self._log_fsm_transition(
-                request=request,
-                obj=obj,
-                field=transition_func._django_fsm.field,
             )
             return True
 

--- a/django_fsm/admin.py
+++ b/django_fsm/admin.py
@@ -281,6 +281,31 @@ class FSMAdminMixin(_ModelAdmin):
         else:
             transition_func(**kwargs)
 
+    def _check_fsm_transition_perm(
+        self, *, obj: fsm._FSMModel, transition: fsm.Transition, request: http.HttpRequest
+    ) -> bool:
+        """Check `has_perm()`, messaging the user on denial."""
+        if transition.has_perm(obj, user=request.user):
+            return True
+
+        self.message_user(
+            request=request,
+            message=self.fsm_transition_not_allowed_msg.format(
+                transition_name=transition.name,
+            ),
+            level=messages.ERROR,
+        )
+        return False
+
+    def _log_fsm_transition(
+        self, *, request: http.HttpRequest, obj: fsm._FSMModel, field: fsm.FSMFieldMixin
+    ) -> None:
+        """Record the transition in the admin change history (LogEntry)."""
+        try:
+            self.log_change(request, obj, [{"changed": {"fields": [str(field.verbose_name)]}}])
+        except Exception:
+            logger.exception("Failed to write admin log entry for FSM transition")
+
     def _apply_fsm_transition(
         self,
         *,
@@ -289,11 +314,15 @@ class FSMAdminMixin(_ModelAdmin):
         request: http.HttpRequest,
         kwargs: typing.Mapping[str, typing.Any] | None = None,
     ) -> bool:
+        transition_func = self._get_fsm_transition_func(obj=obj, transition_name=transition_name)
+        transition = self._get_fsm_transition_by_name(obj=obj, transition_name=transition_name)
+
+        if not self._check_fsm_transition_perm(obj=obj, transition=transition, request=request):
+            return False
+
         try:
             self._execute_fsm_transition(
-                transition_func=self._get_fsm_transition_func(
-                    obj=obj, transition_name=transition_name
-                ),
+                transition_func=transition_func,
                 request=request,
                 kwargs=kwargs,
             )
@@ -336,6 +365,11 @@ class FSMAdminMixin(_ModelAdmin):
                 ),
                 level=messages.SUCCESS,
             )
+            self._log_fsm_transition(
+                request=request,
+                obj=obj,
+                field=transition_func._django_fsm.field,  # type: ignore[attr-defined]
+            )
             return True
 
     # Form handling
@@ -351,14 +385,7 @@ class FSMAdminMixin(_ModelAdmin):
 
         transition = self._get_fsm_transition_by_name(obj=obj, transition_name=transition_name)
 
-        if not transition.has_perm(obj, user=request.user):
-            self.message_user(
-                request=request,
-                message=self.fsm_transition_not_allowed_msg.format(
-                    transition_name=transition_name,
-                ),
-                level=messages.ERROR,
-            )
+        if not self._check_fsm_transition_perm(obj=obj, transition=transition, request=request):
             return redirect(
                 f"admin:{self.model._meta.app_label}_{self.model._meta.model_name}_change",
                 object_id=obj.pk,

--- a/tests/testapp/tests/test_admin.py
+++ b/tests/testapp/tests/test_admin.py
@@ -212,25 +212,6 @@ class ModelAdminTestCase(TestCase):
 
         assert called["comment"] == "Because"
 
-    def test_log_fsm_transition_stringifies_lazy_verbose_name(self) -> None:
-        from django.utils.functional import Promise
-        from django.utils.translation import gettext_lazy as _
-
-        fake_field = mock.Mock(verbose_name=_("Fancy State"))
-
-        with mock.patch.object(self.model_admin, "log_change") as mock_log_change:
-            self.model_admin._log_fsm_transition(
-                request=self.request, obj=self.blog_post, field=fake_field
-            )
-
-        mock_log_change.assert_called_once_with(
-            self.request,
-            self.blog_post,
-            [{"changed": {"fields": ["Fancy State"]}}],
-        )
-        logged_field_name = mock_log_change.call_args[0][2][0]["changed"]["fields"][0]
-        assert not isinstance(logged_field_name, Promise)
-
     # Context
     def test_get_fsm_extra_context_filters_admin_hidden(
         self,
@@ -480,47 +461,6 @@ class ResponseChangeViewTestCase(BaseAdminTestCase):
         assert blog_post.state == AdminBlogPostState.REVIEWED
 
         self.assert_state_log_for_user()
-
-    def test_transition_applied_writes_admin_log_entry(self, mock_message_user: mock.Mock) -> None:
-        assert LogEntry.objects.count() == 0
-
-        blog_post = AdminBlogPost.objects.create(title="Article name")
-
-        self.model_admin.response_change(
-            request=self.make_request(
-                data={"_fsm_transition_to": "moderate"},
-            ),
-            obj=blog_post,
-        )
-
-        log_entry = LogEntry.objects.get()
-        assert log_entry.user == self.user
-        assert log_entry.action_flag == admin.models.CHANGE
-        assert "state" in log_entry.get_change_message()
-
-    def test_transition_applied_swallows_log_change_failure(
-        self, mock_message_user: mock.Mock
-    ) -> None:
-        """A broken audit log must never turn a successful transition into an
-        error response for the admin user."""
-        blog_post = AdminBlogPost.objects.create(title="Article name")
-
-        with mock.patch.object(self.model_admin, "log_change", side_effect=Exception("boom")):
-            self.model_admin.response_change(
-                request=self.make_request(
-                    data={"_fsm_transition_to": "moderate"},
-                ),
-                obj=blog_post,
-            )
-
-        mock_message_user.assert_called_once_with(
-            request=mock.ANY,
-            message="FSM transition 'moderate' succeeded.",
-            level=messages.SUCCESS,
-        )
-
-        blog_post.refresh_from_db()
-        assert blog_post.state == AdminBlogPostState.REVIEWED
 
     def test_permission_denied_transition_is_blocked_without_form(
         self, mock_message_user: mock.Mock
@@ -900,54 +840,6 @@ class TransitionViewTestCase(BaseAdminTestCase):
             state=AdminBlogPostState.CREATED,
             transition="complex_transition",
         )
-
-    def test_transition_form_submission_writes_admin_log_entry(
-        self, mock_message_user: mock.Mock
-    ) -> None:
-        assert LogEntry.objects.count() == 0
-
-        self.model_admin.fsm_transition_view(
-            request=self.make_request(
-                data={
-                    "title": "New Title",
-                    "comment": "Because",
-                    "description": "Because",
-                },
-            ),
-            object_id=str(self.blog_post.pk),
-            transition_name="complex_transition",
-        )
-
-        log_entry = LogEntry.objects.get()
-        assert log_entry.user == self.user
-        assert log_entry.action_flag == admin.models.CHANGE
-        assert "state" in log_entry.get_change_message()
-
-    def test_transition_form_submission_swallows_log_change_failure(
-        self, mock_message_user: mock.Mock
-    ) -> None:
-        with mock.patch.object(self.model_admin, "log_change", side_effect=Exception("boom")):
-            res = self.model_admin.fsm_transition_view(
-                request=self.make_request(
-                    data={
-                        "title": "New Title",
-                        "comment": "Because",
-                        "description": "Because",
-                    },
-                ),
-                object_id=str(self.blog_post.pk),
-                transition_name="complex_transition",
-            )
-
-        assert isinstance(res, HttpResponseRedirect)
-        mock_message_user.assert_called_once_with(
-            request=mock.ANY,
-            message="FSM transition 'complex_transition' succeeded.",
-            level=messages.SUCCESS,
-        )
-
-        self.blog_post.refresh_from_db()
-        assert self.blog_post.state == AdminBlogPostState.CREATED
 
     # Rendering
     def test_transition_form_rendered(self, mock_message_user: mock.Mock) -> None:

--- a/tests/testapp/tests/test_admin.py
+++ b/tests/testapp/tests/test_admin.py
@@ -575,10 +575,12 @@ class ResponseChangeViewTestCase(BaseAdminTestCase):
         blog_post = AdminBlogPost.objects.create(title="Article name")
         assert blog_post.state == AdminBlogPostState.CREATED
 
-        with mock.patch(
-            "tests.testapp.models.AdminBlogPost.moderate",
+        failing_moderate = mock.Mock(
+            _django_fsm=AdminBlogPost.moderate._django_fsm,  # type: ignore[attr-defined]
             side_effect=fsm.ConcurrentTransition("error message"),
-        ):
+        )
+
+        with mock.patch("tests.testapp.models.AdminBlogPost.moderate", failing_moderate):
             self.model_admin.response_change(
                 request=self.make_request(
                     data={"_fsm_transition_to": "moderate"},

--- a/tests/testapp/tests/test_admin.py
+++ b/tests/testapp/tests/test_admin.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 from django.contrib import admin
 from django.contrib import messages
+from django.contrib.admin.models import LogEntry
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
@@ -210,6 +211,25 @@ class ModelAdminTestCase(TestCase):
             )
 
         assert called["comment"] == "Because"
+
+    def test_log_fsm_transition_stringifies_lazy_verbose_name(self) -> None:
+        from django.utils.functional import Promise
+        from django.utils.translation import gettext_lazy as _
+
+        fake_field = mock.Mock(verbose_name=_("Fancy State"))
+
+        with mock.patch.object(self.model_admin, "log_change") as mock_log_change:
+            self.model_admin._log_fsm_transition(
+                request=self.request, obj=self.blog_post, field=fake_field
+            )
+
+        mock_log_change.assert_called_once_with(
+            self.request,
+            self.blog_post,
+            [{"changed": {"fields": ["Fancy State"]}}],
+        )
+        logged_field_name = mock_log_change.call_args[0][2][0]["changed"]["fields"][0]
+        assert not isinstance(logged_field_name, Promise)
 
     # Context
     def test_get_fsm_extra_context_filters_admin_hidden(
@@ -461,6 +481,71 @@ class ResponseChangeViewTestCase(BaseAdminTestCase):
 
         self.assert_state_log_for_user()
 
+    def test_transition_applied_writes_admin_log_entry(self, mock_message_user: mock.Mock) -> None:
+        assert LogEntry.objects.count() == 0
+
+        blog_post = AdminBlogPost.objects.create(title="Article name")
+
+        self.model_admin.response_change(
+            request=self.make_request(
+                data={"_fsm_transition_to": "moderate"},
+            ),
+            obj=blog_post,
+        )
+
+        log_entry = LogEntry.objects.get()
+        assert log_entry.user == self.user
+        assert log_entry.action_flag == admin.models.CHANGE
+        assert "state" in log_entry.get_change_message()
+
+    def test_transition_applied_swallows_log_change_failure(
+        self, mock_message_user: mock.Mock
+    ) -> None:
+        """A broken audit log must never turn a successful transition into an
+        error response for the admin user."""
+        blog_post = AdminBlogPost.objects.create(title="Article name")
+
+        with mock.patch.object(self.model_admin, "log_change", side_effect=Exception("boom")):
+            self.model_admin.response_change(
+                request=self.make_request(
+                    data={"_fsm_transition_to": "moderate"},
+                ),
+                obj=blog_post,
+            )
+
+        mock_message_user.assert_called_once_with(
+            request=mock.ANY,
+            message="FSM transition 'moderate' succeeded.",
+            level=messages.SUCCESS,
+        )
+
+        blog_post.refresh_from_db()
+        assert blog_post.state == AdminBlogPostState.REVIEWED
+
+    def test_permission_denied_transition_is_blocked_without_form(
+        self, mock_message_user: mock.Mock
+    ) -> None:
+        self.assert_state_log_empty()
+        original_state = self.blog_post.state
+
+        self.model_admin.response_change(
+            request=self.make_request(
+                data={"_fsm_transition_to": "permission_denied"},
+            ),
+            obj=self.blog_post,
+        )
+
+        mock_message_user.assert_called_once_with(
+            request=mock.ANY,
+            message="FSM transition 'permission_denied' is not allowed.",
+            level=messages.ERROR,
+        )
+
+        self.blog_post.refresh_from_db()
+        assert self.blog_post.state == original_state
+        self.assert_state_log_empty()
+        assert LogEntry.objects.count() == 0
+
     def test_transition_not_allowed_exception(self, mock_message_user: mock.Mock) -> None:
         self.assert_state_log_empty()
 
@@ -687,22 +772,15 @@ class TransitionViewTestCase(BaseAdminTestCase):
     def test_permission_denied(self, mock_message_user: mock.Mock) -> None:
         self.assert_state_log_empty()
 
-        with mock.patch.object(
-            self.model_admin,
-            "fsm_forms",
-            {
-                "permission_denied": FSMLogDescriptionForm,
-            },
-        ):
-            self.model_admin.fsm_transition_view(
-                request=self.make_request(
-                    data={
-                        "description": "Because",
-                    },
-                ),
-                object_id=str(self.blog_post.pk),
-                transition_name="permission_denied",
-            )
+        self.model_admin.fsm_transition_view(
+            request=self.make_request(
+                data={
+                    "description": "Because",
+                },
+            ),
+            object_id=str(self.blog_post.pk),
+            transition_name="permission_denied",
+        )
 
         mock_message_user.assert_called_once_with(
             request=mock.ANY,
@@ -772,7 +850,7 @@ class TransitionViewTestCase(BaseAdminTestCase):
         )
         self.assert_state_log_empty()
 
-    def test_transition_without_form_(self, mock_message_user: mock.Mock) -> None:
+    def test_transition_without_form(self, mock_message_user: mock.Mock) -> None:
         self.assert_state_log_empty()
 
         res = self.model_admin.fsm_transition_view(
@@ -820,6 +898,54 @@ class TransitionViewTestCase(BaseAdminTestCase):
             state=AdminBlogPostState.CREATED,
             transition="complex_transition",
         )
+
+    def test_transition_form_submission_writes_admin_log_entry(
+        self, mock_message_user: mock.Mock
+    ) -> None:
+        assert LogEntry.objects.count() == 0
+
+        self.model_admin.fsm_transition_view(
+            request=self.make_request(
+                data={
+                    "title": "New Title",
+                    "comment": "Because",
+                    "description": "Because",
+                },
+            ),
+            object_id=str(self.blog_post.pk),
+            transition_name="complex_transition",
+        )
+
+        log_entry = LogEntry.objects.get()
+        assert log_entry.user == self.user
+        assert log_entry.action_flag == admin.models.CHANGE
+        assert "state" in log_entry.get_change_message()
+
+    def test_transition_form_submission_swallows_log_change_failure(
+        self, mock_message_user: mock.Mock
+    ) -> None:
+        with mock.patch.object(self.model_admin, "log_change", side_effect=Exception("boom")):
+            res = self.model_admin.fsm_transition_view(
+                request=self.make_request(
+                    data={
+                        "title": "New Title",
+                        "comment": "Because",
+                        "description": "Because",
+                    },
+                ),
+                object_id=str(self.blog_post.pk),
+                transition_name="complex_transition",
+            )
+
+        assert isinstance(res, HttpResponseRedirect)
+        mock_message_user.assert_called_once_with(
+            request=mock.ANY,
+            message="FSM transition 'complex_transition' succeeded.",
+            level=messages.SUCCESS,
+        )
+
+        self.blog_post.refresh_from_db()
+        assert self.blog_post.state == AdminBlogPostState.CREATED
 
     # Rendering
     def test_transition_form_rendered(self, mock_message_user: mock.Mock) -> None:

--- a/tests/testapp/tests/test_admin.py
+++ b/tests/testapp/tests/test_admin.py
@@ -773,15 +773,22 @@ class TransitionViewTestCase(BaseAdminTestCase):
     def test_permission_denied(self, mock_message_user: mock.Mock) -> None:
         self.assert_state_log_empty()
 
-        self.model_admin.fsm_transition_view(
-            request=self.make_request(
-                data={
-                    "description": "Because",
-                },
-            ),
-            object_id=str(self.blog_post.pk),
-            transition_name="permission_denied",
-        )
+        with mock.patch.object(
+            self.model_admin,
+            "fsm_forms",
+            {
+                "permission_denied": FSMLogDescriptionForm,
+            },
+        ):
+            self.model_admin.fsm_transition_view(
+                request=self.make_request(
+                    data={
+                        "description": "Because",
+                    },
+                ),
+                object_id=str(self.blog_post.pk),
+                transition_name="permission_denied",
+            )
 
         mock_message_user.assert_called_once_with(
             request=mock.ANY,


### PR DESCRIPTION
## Description

- **No permission enforcement on some paths.** `_apply_fsm_transition` never checked `transition.has_perm()`, so a transition's `permission` was silently ignored when applied via the submit-row button for transitions with *no form configured* (the common case) or via a custom admin action that calls `_apply_fsm_transition` directly. Transitions *with* a form were already safe — `fsm_transition_view` has its own pre-existing `has_perm()` check.

Another issue found during development but was not fixed here:
- `_get_fsm_transition_by_name` returns an arbitrary `Transition` entry (`transitions[0]`) rather than the one matching the object's current state. If a transition method is decorated multiple times with a different `permission` per source state, the wrong one could be checked.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (no functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
- [x] Tests added/updated for the changes
- [x] All tests pass locally (`uv run pytest` or `pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [ ] Documentation updated (if applicable)
- [x] CHANGELOG.rst updated (for user-facing changes)

## Testing

<!-- Describe how you tested these changes -->



## Related Issues

<!-- Link any related issues: Fixes #123, Related to #456 -->
