### PR TITLE
Log FSM transitions in admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Unreleased
 - Add ``NoTransition`` and ``InvalidTransition`` subclasses for ``TransitionNotAllowed``
 - Move admin transition buttons after save buttons so that a transition is not used as the default button when pressing the Enter key (#145)
 - Fix stray "None"s in admin when a transition has no configured ``help_text`` (#148)
+- Fix ``FSMAdminMixin`` not writing a Django admin ``LogEntry`` for applied transitions,
+  so state changes made in the admin no longer disappear from the object's "History"
 
 
 django-fsm-2 4.2.4 2026-03-16

--- a/django_fsm/admin.py
+++ b/django_fsm/admin.py
@@ -281,6 +281,15 @@ class FSMAdminMixin(_ModelAdmin):
         else:
             transition_func(**kwargs)
 
+    def _log_fsm_transition(
+        self, *, request: http.HttpRequest, obj: fsm._FSMModel, field: fsm.FSMFieldMixin
+    ) -> None:
+        """Record the transition in the admin change history (LogEntry)."""
+        try:
+            self.log_change(request, obj, [{"changed": {"fields": [str(field.verbose_name)]}}])
+        except Exception:
+            logger.exception("Failed to write admin log entry for FSM transition")
+
     def _apply_fsm_transition(
         self,
         *,
@@ -289,11 +298,10 @@ class FSMAdminMixin(_ModelAdmin):
         request: http.HttpRequest,
         kwargs: typing.Mapping[str, typing.Any] | None = None,
     ) -> bool:
+        transition_func = self._get_fsm_transition_func(obj=obj, transition_name=transition_name)
         try:
             self._execute_fsm_transition(
-                transition_func=self._get_fsm_transition_func(
-                    obj=obj, transition_name=transition_name
-                ),
+                transition_func=transition_func,
                 request=request,
                 kwargs=kwargs,
             )
@@ -335,6 +343,11 @@ class FSMAdminMixin(_ModelAdmin):
                     transition_name=transition_name,
                 ),
                 level=messages.SUCCESS,
+            )
+            self._log_fsm_transition(
+                request=request,
+                obj=obj,
+                field=transition_func._django_fsm.field,  # type: ignore[attr-defined]
             )
             return True
 

--- a/tests/testapp/tests/test_admin.py
+++ b/tests/testapp/tests/test_admin.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 from django.contrib import admin
 from django.contrib import messages
+from django.contrib.admin.models import LogEntry
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
@@ -210,6 +211,25 @@ class ModelAdminTestCase(TestCase):
             )
 
         assert called["comment"] == "Because"
+
+    def test_log_fsm_transition_stringifies_lazy_verbose_name(self) -> None:
+        from django.utils.functional import Promise
+        from django.utils.translation import gettext_lazy as _
+
+        fake_field = mock.Mock(verbose_name=_("Fancy State"))
+
+        with mock.patch.object(self.model_admin, "log_change") as mock_log_change:
+            self.model_admin._log_fsm_transition(
+                request=self.request, obj=self.blog_post, field=fake_field
+            )
+
+        mock_log_change.assert_called_once_with(
+            self.request,
+            self.blog_post,
+            [{"changed": {"fields": ["Fancy State"]}}],
+        )
+        logged_field_name = mock_log_change.call_args[0][2][0]["changed"]["fields"][0]
+        assert not isinstance(logged_field_name, Promise)
 
     # Context
     def test_get_fsm_extra_context_filters_admin_hidden(
@@ -460,6 +480,47 @@ class ResponseChangeViewTestCase(BaseAdminTestCase):
         assert blog_post.state == AdminBlogPostState.REVIEWED
 
         self.assert_state_log_for_user()
+
+    def test_transition_applied_writes_admin_log_entry(self, mock_message_user: mock.Mock) -> None:
+        assert LogEntry.objects.count() == 0
+
+        blog_post = AdminBlogPost.objects.create(title="Article name")
+
+        self.model_admin.response_change(
+            request=self.make_request(
+                data={"_fsm_transition_to": "moderate"},
+            ),
+            obj=blog_post,
+        )
+
+        log_entry = LogEntry.objects.get()
+        assert log_entry.user == self.user
+        assert log_entry.action_flag == admin.models.CHANGE
+        assert "state" in log_entry.get_change_message()
+
+    def test_transition_applied_swallows_log_change_failure(
+        self, mock_message_user: mock.Mock
+    ) -> None:
+        """A broken audit log must never turn a successful transition into an
+        error response for the admin user."""
+        blog_post = AdminBlogPost.objects.create(title="Article name")
+
+        with mock.patch.object(self.model_admin, "log_change", side_effect=Exception("boom")):
+            self.model_admin.response_change(
+                request=self.make_request(
+                    data={"_fsm_transition_to": "moderate"},
+                ),
+                obj=blog_post,
+            )
+
+        mock_message_user.assert_called_once_with(
+            request=mock.ANY,
+            message="FSM transition 'moderate' succeeded.",
+            level=messages.SUCCESS,
+        )
+
+        blog_post.refresh_from_db()
+        assert blog_post.state == AdminBlogPostState.REVIEWED
 
     def test_transition_not_allowed_exception(self, mock_message_user: mock.Mock) -> None:
         self.assert_state_log_empty()
@@ -820,6 +881,54 @@ class TransitionViewTestCase(BaseAdminTestCase):
             state=AdminBlogPostState.CREATED,
             transition="complex_transition",
         )
+
+    def test_transition_form_submission_writes_admin_log_entry(
+        self, mock_message_user: mock.Mock
+    ) -> None:
+        assert LogEntry.objects.count() == 0
+
+        self.model_admin.fsm_transition_view(
+            request=self.make_request(
+                data={
+                    "title": "New Title",
+                    "comment": "Because",
+                    "description": "Because",
+                },
+            ),
+            object_id=str(self.blog_post.pk),
+            transition_name="complex_transition",
+        )
+
+        log_entry = LogEntry.objects.get()
+        assert log_entry.user == self.user
+        assert log_entry.action_flag == admin.models.CHANGE
+        assert "state" in log_entry.get_change_message()
+
+    def test_transition_form_submission_swallows_log_change_failure(
+        self, mock_message_user: mock.Mock
+    ) -> None:
+        with mock.patch.object(self.model_admin, "log_change", side_effect=Exception("boom")):
+            res = self.model_admin.fsm_transition_view(
+                request=self.make_request(
+                    data={
+                        "title": "New Title",
+                        "comment": "Because",
+                        "description": "Because",
+                    },
+                ),
+                object_id=str(self.blog_post.pk),
+                transition_name="complex_transition",
+            )
+
+        assert isinstance(res, HttpResponseRedirect)
+        mock_message_user.assert_called_once_with(
+            request=mock.ANY,
+            message="FSM transition 'complex_transition' succeeded.",
+            level=messages.SUCCESS,
+        )
+
+        self.blog_post.refresh_from_db()
+        assert self.blog_post.state == AdminBlogPostState.CREATED
 
     # Rendering
     def test_transition_form_rendered(self, mock_message_user: mock.Mock) -> None:

--- a/tests/testapp/tests/test_admin.py
+++ b/tests/testapp/tests/test_admin.py
@@ -20,6 +20,8 @@ from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import modify_settings
 from django.urls import reverse
+from django.utils.functional import Promise
+from django.utils.translation import gettext_lazy as _
 from django_fsm_log.models import StateLog
 
 import django_fsm as fsm
@@ -213,9 +215,6 @@ class ModelAdminTestCase(TestCase):
         assert called["comment"] == "Because"
 
     def test_log_fsm_transition_stringifies_lazy_verbose_name(self) -> None:
-        from django.utils.functional import Promise
-        from django.utils.translation import gettext_lazy as _
-
         fake_field = mock.Mock(verbose_name=_("Fancy State"))
 
         with mock.patch.object(self.model_admin, "log_change") as mock_log_change:


### PR DESCRIPTION
## Description

FSMAdminMixin never wrote a Django admin LogEntry for any admin-applied transition, so state changes vanished from the object's History. Add a _log_fsm_transition helper, called from _apply_fsm_transition after a transition succeeds, which writes a LogEntry via the standard log_change() hook. Failures to write the log entry are caught and logged rather than surfaced as a transition failure.

Another issue found during development but was not fixed here:
There's a pre-existing double-save/duplicate-`StateLog`-entry issue when applying a transition via the admin submit-row button (Django's standard change-form save runs first, then `_apply_fsm_transition` saves again). Fixing it properly would mean moving transition execution into `save_model()`, which is a more invasive refactor than seemed appropriate for this PR.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (no functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
- [x] Tests added/updated for the changes
- [x] All tests pass locally (`uv run pytest` or `pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [ ] Documentation updated (if applicable)
- [x] CHANGELOG.rst updated (for user-facing changes)

## Testing

<!-- Describe how you tested these changes -->


## Related Issues

<!-- Link any related issues: Fixes #123, Related to #456 -->
