### PR TITLE
Typing: Improve transition decorated typing inference

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -55,7 +55,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
         """A `@transition`-decorated method"""
 
         __name__: str
-        __qualname__: str
+
         _django_fsm: FSMMeta
 
         def __call__(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Any: ...

--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -46,18 +46,16 @@ if typing.TYPE_CHECKING:  # pragma: no cover
     _Permission: typing.TypeAlias = str | typing.Callable[[_FSMModel, UserWithPermissions], bool]
     _Condition: typing.TypeAlias = typing.Callable[[_FSMModel], bool]
 
+    _TransitionF = typing.TypeVar(
+        "_TransitionF",
+        bound=typing.Callable[..., _StateValue | typing.Any | None],
+    )
+
     class _TransitionMethod(typing.Protocol):
         """A `@transition`-decorated method"""
 
         __name__: str
         __qualname__: str
-        _django_fsm: FSMMeta
-
-        def __call__(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Any: ...
-
-    class _TransitionMethod(typing.Protocol):
-        """A `@transition`-decorated method"""
-
         _django_fsm: FSMMeta
 
         def __call__(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Any: ...
@@ -103,7 +101,7 @@ ANY_OTHER_STATE = "+"
 class Transition:
     def __init__(
         self,
-        method: typing.Callable[..., _StateValue | typing.Any | None],
+        method: _TransitionF,
         source: _StateValue,
         target: _StateValue,
         on_error: _StateValue | None,
@@ -206,9 +204,9 @@ class FSMMeta:
         self.field = field
         self.transitions = {}
 
-    def get_transition(self, source: _StateValue) -> Transition | None:
+    def get_transition(self, source: _StateValue | None) -> Transition | None:
         return (
-            self.transitions.get(source, None)
+            self.transitions.get(source, None)  # type: ignore[arg-type]
             or self.transitions.get(ANY_STATE, None)
             or self.transitions.get(ANY_OTHER_STATE, None)
         )
@@ -236,7 +234,7 @@ class FSMMeta:
             custom=custom,
         )
 
-    def has_transition(self, state: _StateValue) -> bool:
+    def has_transition(self, state: _StateValue | None) -> bool:
         """
         Lookup if any transition exists from current model state using current method
         """
@@ -254,7 +252,7 @@ class FSMMeta:
 
         return False
 
-    def conditions_met(self, instance: _FSMModel, state: _StateValue) -> bool:
+    def conditions_met(self, instance: _FSMModel, state: _StateValue | None) -> bool:
         """
         Check if all conditions have been met
         """
@@ -269,7 +267,7 @@ class FSMMeta:
         return all(condition(instance) for condition in transition.conditions)
 
     def get_first_unmet_condition(
-        self, instance: _FSMModel, state: _StateValue
+        self, instance: _FSMModel, state: _StateValue | None
     ) -> _Condition | None:
         """
         Return the first condition callable that is not met, or None.
@@ -289,7 +287,7 @@ class FSMMeta:
         return None
 
     def has_transition_perm(
-        self, instance: _FSMModel, state: _StateValue, user: UserWithPermissions
+        self, instance: _FSMModel, state: _StateValue | None, user: UserWithPermissions
     ) -> bool:
         transition = self.get_transition(state)
 
@@ -298,7 +296,7 @@ class FSMMeta:
 
         return transition.has_perm(instance, user)
 
-    def next_state(self, current_state: _StateValue) -> _StateValue:
+    def next_state(self, current_state: _StateValue | None) -> _StateValue:
         transition = self.get_transition(current_state)
 
         if transition is None:  # pragma: no cover
@@ -306,7 +304,7 @@ class FSMMeta:
 
         return transition.target
 
-    def exception_state(self, current_state: _StateValue) -> _StateValue | None:
+    def exception_state(self, current_state: _StateValue | None) -> _StateValue | None:
         transition = self.get_transition(current_state)
 
         if transition is None:  # pragma: no cover
@@ -319,7 +317,11 @@ class FSMFieldDescriptor:
     def __init__(self, field: FSMFieldMixin) -> None:
         self.field = field
 
-    def __get__(self, instance: _FSMModel, cls: typing.Any | None = None) -> typing.Any:
+    def __get__(
+        self,
+        instance: _FSMModel | None,
+        cls: type[_FSMModel] | None = None,
+    ) -> _StateValue | None | FSMFieldDescriptor:
         if instance is None:
             return self
         return self.field.get_state(instance)
@@ -369,10 +371,10 @@ class FSMFieldMixin(_Field):
             kwargs["protected"] = self.protected
         return name, path, args, kwargs
 
-    def get_state(self, instance: _FSMModel) -> typing.Any:
+    def get_state(self, instance: _FSMModel) -> _StateValue | None:
         # The state field may be deferred. We delegate the logic of figuring this out
         # and loading the deferred field on-demand to Django's built-in DeferredAttribute class.
-        return DeferredAttribute(self).__get__(instance)
+        return DeferredAttribute(self).__get__(instance)  # type: ignore[no-any-return]
 
     def set_state(self, instance: _FSMModel, state: _StateValue) -> None:
         instance.__dict__[self.name] = state
@@ -551,8 +553,8 @@ class FSMKeyField(FSMFieldMixin, ForeignKey):
     State Machine support for Django model
     """
 
-    def get_state(self, instance: _FSMModel) -> typing.Any:
-        return instance.__dict__[self.attname]
+    def get_state(self, instance: _FSMModel) -> _StateValue | None:
+        return instance.__dict__[self.attname]  # type: ignore[no-any-return]
 
     def set_state(self, instance: _FSMModel, state: _StateValue) -> None:
         instance.__dict__[self.attname] = self.to_python(state)
@@ -698,7 +700,7 @@ def transition(
     conditions: list[_Condition] | None = None,
     permission: _Permission | None = None,
     custom: dict[str, typing.Any] | None = None,
-) -> typing.Callable[[typing.Any], typing.Any]:
+) -> typing.Callable[[_TransitionF], _TransitionF]:
     """
     Method decorator to mark allowed transitions.
 
@@ -706,7 +708,7 @@ def transition(
     has not changed after the function call.
     """
 
-    def inner_transition(func: typing.Any) -> typing.Any:
+    def inner_transition(func: _TransitionF) -> _TransitionF:
         fsm_meta = getattr(func, "_django_fsm", None)
         if fsm_meta:
             wrapper_installed = True
@@ -715,14 +717,22 @@ def transition(
             fsm_meta = FSMMeta(field=field, method=func)
             setattr(func, "_django_fsm", fsm_meta)
 
+        method = typing.cast("_TransitionMethod", func)
+        target_state = typing.cast("_StateValue", target)
         if isinstance(source, list | tuple | set):
             for state in source:
-                func._django_fsm.add_transition(
-                    func, state, target, on_error, conditions, permission, custom
+                fsm_meta.add_transition(
+                    method, state, target_state, on_error, conditions, permission, custom
                 )
         else:
-            func._django_fsm.add_transition(
-                func, source, target, on_error, conditions, permission, custom
+            fsm_meta.add_transition(
+                method,
+                typing.cast("_StateValue", source),
+                target_state,
+                on_error,
+                conditions,
+                permission,
+                custom,
             )
 
         @wraps(func)
@@ -730,10 +740,10 @@ def transition(
             instance: _FSMModel, *args: typing.Any, **kwargs: typing.Any
         ) -> typing.Any:
             assert isinstance(fsm_meta.field, FSMFieldMixin)
-            return fsm_meta.field.change_state(instance, func, *args, **kwargs)
+            return fsm_meta.field.change_state(instance, method, *args, **kwargs)
 
         if not wrapper_installed:
-            return _change_state
+            return typing.cast("_TransitionF", _change_state)
 
         return func
 

--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -45,7 +45,15 @@ if typing.TYPE_CHECKING:  # pragma: no cover
     _StateValue: typing.TypeAlias = str | int | models.Choices
     _Permission: typing.TypeAlias = str | typing.Callable[[_FSMModel, UserWithPermissions], bool]
     _Condition: typing.TypeAlias = typing.Callable[[_FSMModel], bool]
-    _TransitionFunc: typing.TypeAlias = typing.Callable[..., _StateValue | typing.Any | None]
+
+    class _TransitionMethod(typing.Protocol):
+        """A `@transition`-decorated method"""
+
+        __name__: str
+        __qualname__: str
+        _django_fsm: FSMMeta
+
+        def __call__(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Any: ...
 
     class _TransitionMethod(typing.Protocol):
         """A `@transition`-decorated method"""
@@ -95,7 +103,7 @@ ANY_OTHER_STATE = "+"
 class Transition:
     def __init__(
         self,
-        method: _TransitionFunc,
+        method: typing.Callable[..., _StateValue | typing.Any | None],
         source: _StateValue,
         target: _StateValue,
         on_error: _StateValue | None,
@@ -207,7 +215,7 @@ class FSMMeta:
 
     def add_transition(
         self,
-        method: _TransitionFunc,
+        method: _TransitionMethod,
         source: _StateValue,
         target: _StateValue,
         on_error: _StateValue | None = None,
@@ -393,7 +401,7 @@ class FSMFieldMixin(_Field):
     def change_state(
         self,
         instance: _FSMModel,
-        method: typing.Any,
+        method: _TransitionMethod,
         *args: typing.Any,
         **kwargs: typing.Any,
     ) -> typing.Any:
@@ -498,7 +506,7 @@ class FSMFieldMixin(_Field):
         if not issubclass(sender, self.base_cls):
             return
 
-        def is_field_transition_method(attr: _TransitionFunc) -> bool:
+        def is_field_transition_method(attr: object) -> bool:
             return (
                 (inspect.ismethod(attr) or inspect.isfunction(attr))
                 and hasattr(attr, "_django_fsm")
@@ -779,7 +787,7 @@ class State:
         result: _StateValue,
         args: typing.Sequence[typing.Any] | None = None,
         kwargs: dict[str, typing.Any] | None = None,
-    ) -> _StateValue:
+    ) -> typing.Any:
         raise NotImplementedError
 
 

--- a/django_fsm/admin.py
+++ b/django_fsm/admin.py
@@ -264,7 +264,7 @@ class FSMAdminMixin(_ModelAdmin):
     def _execute_fsm_transition(
         self,
         *,
-        transition_func: typing.Callable[..., typing.Any],
+        transition_func: fsm._TransitionF,
         request: http.HttpRequest,
         kwargs: typing.Mapping[str, typing.Any] | None = None,
     ) -> None:

--- a/django_fsm/admin.py
+++ b/django_fsm/admin.py
@@ -264,7 +264,7 @@ class FSMAdminMixin(_ModelAdmin):
     def _execute_fsm_transition(
         self,
         *,
-        transition_func: fsm._TransitionFunc,
+        transition_func: typing.Callable[..., typing.Any],
         request: http.HttpRequest,
         kwargs: typing.Mapping[str, typing.Any] | None = None,
     ) -> None:

--- a/django_fsm/exceptions.py
+++ b/django_fsm/exceptions.py
@@ -11,7 +11,7 @@ except ImportError:  # pragma: no cover
 if typing.TYPE_CHECKING:  # pragma: no cover
     from . import _Condition
     from . import _FSMModel
-    from . import _TransitionFunc
+    from . import _TransitionMethod
 
 
 class FSMException(Exception):  # noqa: N818
@@ -30,7 +30,7 @@ class InvalidTransition(TransitionNotAllowed):
     """Raised when a transition method is not valid for the current state"""
 
     object: _FSMModel
-    method: _TransitionFunc
+    method: _TransitionMethod
 
     @override
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -80,7 +80,7 @@ class Application(models.Model):
         source=ApplicationState.NEW,
         target=fsm.RETURN_VALUE(ApplicationState.MODERATED, ApplicationState.BLOCKED),
     )
-    def return_value(self) -> str:
+    def return_value(self) -> ApplicationState:
         return ApplicationState.PUBLISHED
 
     @fsm.transition(
@@ -88,7 +88,7 @@ class Application(models.Model):
         source=fsm.ANY_STATE,
         target=fsm.RETURN_VALUE(ApplicationState.MODERATED, ApplicationState.BLOCKED),
     )
-    def return_value_any_source(self) -> str:
+    def return_value_any_source(self) -> ApplicationState:
         return ApplicationState.PUBLISHED
 
     @fsm.transition(
@@ -96,7 +96,7 @@ class Application(models.Model):
         source=fsm.ANY_OTHER_STATE,
         target=fsm.RETURN_VALUE(ApplicationState.MODERATED, ApplicationState.BLOCKED),
     )
-    def return_value_any_source_except_target(self) -> str:
+    def return_value_any_source_except_target(self) -> ApplicationState:
         return ApplicationState.PUBLISHED
 
     @fsm.transition(
@@ -192,7 +192,7 @@ class FKApplication(models.Model):
         source=ApplicationState.NEW,
         target=fsm.RETURN_VALUE(ApplicationState.MODERATED, ApplicationState.BLOCKED),
     )
-    def return_value(self) -> str:
+    def return_value(self) -> ApplicationState:
         return ApplicationState.MODERATED
 
     @fsm.transition(
@@ -200,7 +200,7 @@ class FKApplication(models.Model):
         source=fsm.ANY_STATE,
         target=fsm.RETURN_VALUE(ApplicationState.MODERATED, ApplicationState.BLOCKED),
     )
-    def return_value_any_source(self) -> str:
+    def return_value_any_source(self) -> ApplicationState:
         return ApplicationState.MODERATED
 
     @fsm.transition(
@@ -208,7 +208,7 @@ class FKApplication(models.Model):
         source=fsm.ANY_OTHER_STATE,
         target=fsm.RETURN_VALUE(ApplicationState.MODERATED, ApplicationState.BLOCKED),
     )
-    def return_value_any_source_except_target(self) -> str:
+    def return_value_any_source_except_target(self) -> ApplicationState:
         return ApplicationState.MODERATED
 
     @fsm.transition(

--- a/tests/testapp/tests/test_abstract_inheritance.py
+++ b/tests/testapp/tests/test_abstract_inheritance.py
@@ -15,7 +15,7 @@ class BaseAbstractModel(models.Model):
         abstract = True
 
     @fsm.transition(field=state, source=ApplicationState.NEW, target=ApplicationState.PUBLISHED)
-    def publish(self):
+    def publish(self) -> None:
         pass
 
 
@@ -29,7 +29,7 @@ class AnotherFromAbstractModel(BaseAbstractModel):
     @fsm.transition(
         field="state", source=ApplicationState.PUBLISHED, target=ApplicationState.STICKED
     )
-    def stick(self):
+    def stick(self) -> None:
         pass
 
 
@@ -37,7 +37,7 @@ class InheritedFromAbstractModel(BaseAbstractModel):
     @fsm.transition(
         field="state", source=ApplicationState.PUBLISHED, target=ApplicationState.STICKED
     )
-    def stick(self):
+    def stick(self) -> None:
         pass
 
 

--- a/tests/testapp/tests/test_access_deferred_fsm_field.py
+++ b/tests/testapp/tests/test_access_deferred_fsm_field.py
@@ -14,11 +14,11 @@ class DeferrableModel(models.Model):
     objects: models.Manager[DeferrableModel] = models.Manager()
 
     @fsm.transition(field=state, source=ApplicationState.NEW, target=ApplicationState.PUBLISHED)
-    def publish(self):
+    def publish(self) -> None:
         pass
 
     @fsm.transition(field=state, source=fsm.ANY_OTHER_STATE, target=ApplicationState.REMOVED)
-    def remove(self):
+    def remove(self) -> None:
         pass
 
 

--- a/tests/testapp/tests/test_admin.py
+++ b/tests/testapp/tests/test_admin.py
@@ -574,12 +574,9 @@ class ResponseChangeViewTestCase(BaseAdminTestCase):
         blog_post = AdminBlogPost.objects.create(title="Article name")
         assert blog_post.state == AdminBlogPostState.CREATED
 
-        failing_moderate = mock.Mock(
-            _django_fsm=AdminBlogPost.moderate._django_fsm,  # type: ignore[attr-defined]
-            side_effect=fsm.ConcurrentTransition("error message"),
-        )
-
-        with mock.patch("tests.testapp.models.AdminBlogPost.moderate", failing_moderate):
+        failing_moderate_mock = mock.MagicMock(side_effect=fsm.ConcurrentTransition("error message"))
+        failing_moderate_mock._django_fsm = AdminBlogPost.moderate._django_fsm  # type: ignore[attr-defined]
+        with mock.patch.object(AdminBlogPost, "moderate", new=failing_moderate_mock):
             self.model_admin.response_change(
                 request=self.make_request(
                     data={"_fsm_transition_to": "moderate"},

--- a/tests/testapp/tests/test_admin.py
+++ b/tests/testapp/tests/test_admin.py
@@ -574,7 +574,9 @@ class ResponseChangeViewTestCase(BaseAdminTestCase):
         blog_post = AdminBlogPost.objects.create(title="Article name")
         assert blog_post.state == AdminBlogPostState.CREATED
 
-        failing_moderate_mock = mock.MagicMock(side_effect=fsm.ConcurrentTransition("error message"))
+        failing_moderate_mock = mock.MagicMock(
+            side_effect=fsm.ConcurrentTransition("error message")
+        )
         failing_moderate_mock._django_fsm = AdminBlogPost.moderate._django_fsm  # type: ignore[attr-defined]
         with mock.patch.object(AdminBlogPost, "moderate", new=failing_moderate_mock):
             self.model_admin.response_change(

--- a/tests/testapp/tests/test_basic_transitions.py
+++ b/tests/testapp/tests/test_basic_transitions.py
@@ -15,19 +15,19 @@ class SimpleBlogPost(models.Model):
     state = fsm.FSMField(choices=ApplicationState.choices, default=ApplicationState.NEW)
 
     @fsm.transition(field=state, source=ApplicationState.NEW, target=ApplicationState.PUBLISHED)
-    def publish(self):
+    def publish(self) -> None:
         pass
 
     @fsm.transition(source=ApplicationState.PUBLISHED, field=state)
-    def notify_all(self):
+    def notify_all(self) -> None:
         pass
 
     @fsm.transition(source=ApplicationState.PUBLISHED, target=ApplicationState.HIDDEN, field=state)
-    def hide(self):
+    def hide(self) -> None:
         pass
 
     @fsm.transition(source=ApplicationState.NEW, target=ApplicationState.REMOVED, field=state)
-    def remove(self):
+    def remove(self) -> None:
         raise Exception("Upss")
 
     @fsm.transition(
@@ -35,25 +35,25 @@ class SimpleBlogPost(models.Model):
         target=ApplicationState.STOLEN,
         field=state,
     )
-    def steal(self):
+    def steal(self) -> None:
         pass
 
     @fsm.transition(source=fsm.ANY_STATE, target=ApplicationState.MODERATED, field=state)
-    def moderate(self):
+    def moderate(self) -> None:
         pass
 
     @fsm.transition(source=fsm.ANY_OTHER_STATE, target=ApplicationState.BLOCKED, field=state)
-    def block(self):
+    def block(self) -> None:
         pass
 
     @fsm.transition(source=fsm.ANY_STATE, target="", field=state)
-    def empty(self):
+    def empty(self) -> None:
         pass
 
 
 class AdvancedBlogPost(SimpleBlogPost):
     @fsm.transition(field="state", source=ApplicationState.NEW, target=ApplicationState.PUBLISHED)
-    def publish(self):
+    def publish(self) -> None:
         pass
 
 

--- a/tests/testapp/tests/test_conditions.py
+++ b/tests/testapp/tests/test_conditions.py
@@ -28,7 +28,7 @@ class BlogPostWithConditions(models.Model):
         target=ApplicationState.PUBLISHED,
         conditions=[condition_func, model_condition],
     )
-    def publish(self):
+    def publish(self) -> None:
         pass
 
     @fsm.transition(
@@ -37,7 +37,7 @@ class BlogPostWithConditions(models.Model):
         target=ApplicationState.REMOVED,
         conditions=[condition_func, unmet_condition],
     )
-    def remove(self):
+    def remove(self) -> None:
         pass
 
 
@@ -105,7 +105,7 @@ class BlogPostShortCircuit(models.Model):
         target="published",
         conditions=[_eval_tracking_condition, _never_reached_condition],
     )
-    def publish(self):
+    def publish(self) -> None:
         pass
 
 

--- a/tests/testapp/tests/test_custom_data.py
+++ b/tests/testapp/tests/test_custom_data.py
@@ -21,7 +21,7 @@ class BlogPostWithCustomData(models.Model):
             "type": "*",
         },
     )
-    def publish(self):
+    def publish(self) -> None:
         pass
 
     @fsm.transition(
@@ -33,7 +33,7 @@ class BlogPostWithCustomData(models.Model):
             "type": "manual",
         },
     )
-    def remove(self):
+    def remove(self) -> None:
         pass
 
     @fsm.transition(
@@ -45,7 +45,7 @@ class BlogPostWithCustomData(models.Model):
             "type": "automated",
         },
     )
-    def moderate(self):
+    def moderate(self) -> None:
         pass
 
 

--- a/tests/testapp/tests/test_exception_transitions.py
+++ b/tests/testapp/tests/test_exception_transitions.py
@@ -19,11 +19,11 @@ class ExceptionalBlogPost(models.Model):
         target=ApplicationState.PUBLISHED,
         on_error=ApplicationState.CRASHED,
     )
-    def publish(self):
+    def publish(self) -> None:
         raise Exception("Upss")
 
     @fsm.transition(field=state, source=ApplicationState.NEW, target=ApplicationState.REMOVED)
-    def delete(self):
+    def remove(self) -> None:
         raise Exception("Upss")
 
 
@@ -50,10 +50,10 @@ class FSMFieldExceptionTest(TestCase):
         assert "exception" in self.post_transition_data
 
     def test_state_unchanged_without_error_target(self):
-        assert fsm.can_proceed(self.model.delete)
+        assert fsm.can_proceed(self.model.remove)
 
         with pytest.raises(Exception, match="Upss"):
-            self.model.delete()
+            self.model.remove()
 
         assert self.model.state == ApplicationState.NEW
         assert self.post_transition_data == {}

--- a/tests/testapp/tests/test_integer_field.py
+++ b/tests/testapp/tests/test_integer_field.py
@@ -13,11 +13,11 @@ class BlogPostWithIntegerField(models.Model):
     state = fsm.FSMIntegerField(choices=BlogPostState.choices, default=BlogPostState.NEW)
 
     @fsm.transition(field=state, source=BlogPostState.NEW, target=BlogPostState.PUBLISHED)
-    def publish(self):
+    def publish(self) -> None:
         pass
 
     @fsm.transition(field=state, source=BlogPostState.PUBLISHED, target=BlogPostState.HIDDEN)
-    def hide(self):
+    def hide(self) -> None:
         pass
 
 

--- a/tests/testapp/tests/test_key_field.py
+++ b/tests/testapp/tests/test_key_field.py
@@ -22,27 +22,27 @@ class FSMKeyModelAbstract(models.Model):
     state: fsm.FSMKeyField
 
     @fsm.transition(field="state", source="_NEW_", target="_PUBLISHED_")
-    def publish(self):
+    def publish(self) -> None:
         pass
 
     @fsm.transition(field="state", source="_PUBLISHED_")
-    def notify_all(self):
+    def notify_all(self) -> None:
         pass
 
     @fsm.transition(field="state", source="_PUBLISHED_", target="_HIDDEN_")
-    def hide(self):
+    def hide(self) -> None:
         pass
 
     @fsm.transition(field="state", source="_NEW_", target="_REMOVED_")
-    def remove(self):
+    def remove(self) -> None:
         raise Exception("Upss")
 
     @fsm.transition(field="state", source=["_PUBLISHED_", "_HIDDEN_"], target="_STOLEN_")
-    def steal(self):
+    def steal(self) -> None:
         pass
 
     @fsm.transition(field="state", source=fsm.ANY_STATE, target="_MODERATED_")
-    def moderate(self):
+    def moderate(self) -> None:
         pass
 
 

--- a/tests/testapp/tests/test_lock_mixin.py
+++ b/tests/testapp/tests/test_lock_mixin.py
@@ -20,7 +20,7 @@ class LockedBlogPost(fsm.ConcurrentTransitionMixin, models.Model):
         source=ApplicationState.NEW,
         target=ApplicationState.PUBLISHED,
     )
-    def publish(self):
+    def publish(self) -> None:
         pass
 
     @fsm.transition(
@@ -28,7 +28,7 @@ class LockedBlogPost(fsm.ConcurrentTransitionMixin, models.Model):
         source=ApplicationState.PUBLISHED,
         target=ApplicationState.REMOVED,
     )
-    def remove(self):
+    def remove(self) -> None:
         pass
 
 
@@ -43,7 +43,7 @@ class ExtendedBlogPost(LockedBlogPost):
         source=ApplicationState.BLOCKED,
         target=ApplicationState.REJECTED,
     )
-    def reject(self):
+    def reject(self) -> None:
         pass
 
 

--- a/tests/testapp/tests/test_mixin_support.py
+++ b/tests/testapp/tests/test_mixin_support.py
@@ -10,11 +10,11 @@ from ..choices import ApplicationState
 
 class WorkflowMixin:
     @fsm.transition(field="state", source=fsm.ANY_STATE, target=ApplicationState.DRAFT)
-    def draft(self):
+    def draft(self) -> None:
         pass
 
     @fsm.transition(field="state", source=ApplicationState.DRAFT, target=ApplicationState.PUBLISHED)
-    def publish(self):
+    def publish(self) -> None:
         pass
 
 

--- a/tests/testapp/tests/test_model_create_with_generic.py
+++ b/tests/testapp/tests/test_model_create_with_generic.py
@@ -26,7 +26,7 @@ class Task(models.Model):
     objects: models.Manager[Task] = models.Manager()
 
     @fsm.transition(field=state, source=TaskState.NEW, target=TaskState.DONE)
-    def do(self):
+    def do(self) -> None:
         pass
 
 

--- a/tests/testapp/tests/test_multi_resultstate.py
+++ b/tests/testapp/tests/test_multi_resultstate.py
@@ -23,11 +23,11 @@ class MultiResultModel(models.Model):
         source=ApplicationState.NEW,
         target=fsm.RETURN_VALUE(ApplicationState.FOR_MODERATORS, ApplicationState.PUBLISHED),
     )
-    def publish(self, *, is_public=False):
+    def publish(self, *, is_public: bool = False) -> ApplicationState:
         return ApplicationState.PUBLISHED if is_public else ApplicationState.FOR_MODERATORS
 
     @fsm.transition(field=state, source=ApplicationState.NEW, target=fsm.RETURN_VALUE())
-    def publish_without_states(self, *, is_public=False):
+    def publish_without_states(self, *, is_public: bool = False) -> ApplicationState:
         return ApplicationState.PUBLISHED if is_public else ApplicationState.FOR_MODERATORS
 
     @fsm.transition(
@@ -38,7 +38,7 @@ class MultiResultModel(models.Model):
             states=[ApplicationState.PUBLISHED, ApplicationState.REJECTED],
         ),
     )
-    def moderate(self, allowed):
+    def moderate(self, *, allowed: bool) -> None:
         pass
 
     @fsm.transition(
@@ -48,7 +48,7 @@ class MultiResultModel(models.Model):
             lambda _, allowed: ApplicationState.PUBLISHED if allowed else ApplicationState.REJECTED,
         ),
     )
-    def moderate_without_states(self, allowed):
+    def moderate_without_states(self, *, allowed: bool) -> None:
         pass
 
 

--- a/tests/testapp/tests/test_multidecorators.py
+++ b/tests/testapp/tests/test_multidecorators.py
@@ -31,7 +31,7 @@ class MultiDecoratedModel(models.Model):
         field=state, source=StateChoice.SUBMITTED_BY_ANONYMOUS, target=StateChoice.REVIEW_ANONYMOUS
     )
     @fsm.transition(field=state, source=fsm.ANY_STATE, target=StateChoice.REVIEW_ANONYMOUS)
-    def review(self):
+    def review(self) -> None:
         self.counter += 1
 
 

--- a/tests/testapp/tests/test_protected_field.py
+++ b/tests/testapp/tests/test_protected_field.py
@@ -17,7 +17,7 @@ class ProtectedAccessModel(models.Model):
     objects: models.Manager[ProtectedAccessModel] = models.Manager()
 
     @fsm.transition(field=status, source=ApplicationState.NEW, target=ApplicationState.PUBLISHED)
-    def publish(self):
+    def publish(self) -> None:
         pass
 
 

--- a/tests/testapp/tests/test_protected_fields.py
+++ b/tests/testapp/tests/test_protected_fields.py
@@ -17,7 +17,7 @@ class RefreshableProtectedAccessModel(models.Model):
     objects: models.Manager[RefreshableProtectedAccessModel] = models.Manager()
 
     @fsm.transition(field=status, source=ApplicationState.NEW, target=ApplicationState.PUBLISHED)
-    def publish(self):
+    def publish(self) -> None:
         pass
 
 

--- a/tests/testapp/tests/test_proxy_inheritance.py
+++ b/tests/testapp/tests/test_proxy_inheritance.py
@@ -12,7 +12,7 @@ class BaseModel(models.Model):
     state = fsm.FSMField(choices=ApplicationState.choices, default=ApplicationState.NEW)
 
     @fsm.transition(field=state, source=ApplicationState.NEW, target=ApplicationState.PUBLISHED)
-    def publish(self):
+    def publish(self) -> None:
         pass
 
 
@@ -23,7 +23,7 @@ class InheritedModel(BaseModel):
     @fsm.transition(
         field="state", source=ApplicationState.PUBLISHED, target=ApplicationState.STICKED
     )
-    def stick(self):
+    def stick(self) -> None:
         pass
 
 

--- a/tests/testapp/tests/test_state_transitions.py
+++ b/tests/testapp/tests/test_state_transitions.py
@@ -21,7 +21,7 @@ class Insect(models.Model):
     objects: models.Manager[Insect] = models.Manager()
 
     @fsm.transition(field=state, source=STATE.CATERPILLAR, target=STATE.BUTTERFLY)
-    def cocoon(self):
+    def cocoon(self) -> None:
         pass
 
     def fly(self):

--- a/tests/testapp/tests/test_string_field_parameter.py
+++ b/tests/testapp/tests/test_string_field_parameter.py
@@ -14,19 +14,19 @@ class BlogPostWithStringField(models.Model):
     @fsm.transition(
         field="state", source=ApplicationState.NEW, target=ApplicationState.PUBLISHED, conditions=[]
     )
-    def publish(self):
+    def publish(self) -> None:
         pass
 
     @fsm.transition(
         field="state", source=ApplicationState.PUBLISHED, target=ApplicationState.REMOVED
     )
-    def remove(self):
+    def remove(self) -> None:
         pass
 
     @fsm.transition(
         field="state", source=ApplicationState.PUBLISHED, target=ApplicationState.MODERATED
     )
-    def review(self):
+    def review(self) -> None:
         pass
 
 

--- a/tests/testapp/tests/test_transition_all_except_target.py
+++ b/tests/testapp/tests/test_transition_all_except_target.py
@@ -12,11 +12,11 @@ class ExceptTargetTransition(models.Model):
     state = fsm.FSMField(choices=ApplicationState.choices, default=ApplicationState.NEW)
 
     @fsm.transition(field=state, source=ApplicationState.NEW, target=ApplicationState.PUBLISHED)
-    def publish(self):
+    def publish(self) -> None:
         pass
 
     @fsm.transition(field=state, source=fsm.ANY_OTHER_STATE, target=ApplicationState.REMOVED)
-    def remove(self):
+    def remove(self) -> None:
         pass
 
 


### PR DESCRIPTION
## Description

Improve typing inference of transition-decorated functions

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (no functional changes)

## Checklist

- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
- [ ] Tests added/updated for the changes
- [ ] All tests pass locally (`uv run pytest` or `pytest`)
- [ ] Linting passes (`uv run ruff check .`)
- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.rst updated (for user-facing changes)

## Testing

<!-- Describe how you tested these changes -->

```bash
# Commands used to test
uv run pytest tests/test_xxx.py -v
```

## Related Issues

<!-- Link any related issues: Fixes #123, Related to #456 -->
